### PR TITLE
feat: Decouple Indicator Registration from Backtest Orchestrator

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -19,6 +19,8 @@ Auto-generated from all feature plans. Last updated: 2025-10-30
 - N/A (results in memory, optional CSV export) (024-parallel-param-sweep)
 - Python 3.11+ + `poetry`, `pydantic` (025-fix-risk-args)
 - N/A (CLI arguments are transient) (025-fix-risk-args)
+- Python 3.11+ + Polars (data processing), Strategy Base Class (026-decouple-indicators)
+- N/A (in-memory processing) (026-decouple-indicators)
 
 - Python 3.13 + numpy, pandas, pydantic, rich (existing); no new dependencies required (002-directional-backtesting)
 - CSV files for price data input; text/JSON files for backtest results output (002-directional-backtesting)
@@ -115,9 +117,9 @@ Python projects MUST use Poetry. Prohibit requirements.txt. All dependencies in 
 - See Constitution Principle XI for full requirements
 
 ## Recent Changes
+- 026-decouple-indicators: Added Python 3.11+ + Polars (data processing), Strategy Base Class
 - 025-fix-risk-args: Added Python 3.11+ + `poetry`, `pydantic`
 - 024-parallel-param-sweep: Added Python 3.13 + Rich (existing), itertools (stdlib), concurrent.futures (via existing parallel.py)
-- 023-session-blackouts: Added Python 3.11+ (per pyproject.toml) + pydantic (validation), pandas/polars (timestamps), pytz (timezone handling)
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/specs/026-decouple-indicators/checklists/requirements.md
+++ b/specs/026-decouple-indicators/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Decouple Indicator Registration
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-01-14
+**Feature**: [026-decouple-indicators/spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Added Edge Cases section covering conflicts, invalid definitions, and missing dependencies.
+- Confirmed "Strategy" and "Indicator" are domain terms, not implementation details.

--- a/specs/026-decouple-indicators/data-model.md
+++ b/specs/026-decouple-indicators/data-model.md
@@ -1,0 +1,45 @@
+# Data Model: Decouple Indicator Registration
+
+## API Schema Changes
+
+### `src.strategy.base.Strategy`
+
+New method signature:
+
+```python
+def get_custom_indicators(self) -> dict[str, Callable[[pl.DataFrame, Any], pl.DataFrame]]:
+    """
+    Define strategy-specific custom indicators.
+
+    Returns:
+        Dictionary mapping indicator name to calculation function.
+        Function signature: (df: pl.DataFrame, **kwargs) -> pl.DataFrame
+    """
+    return {}
+```
+
+### `src.indicators.dispatcher.calculate_indicators`
+
+Updated signature:
+
+```python
+def calculate_indicators(
+    df: pl.DataFrame,
+    indicators: list[str],
+    overrides: dict[str, dict[str, Any]] | None = None,
+    custom_registry: dict[str, Callable] | None = None,  # [NEW]
+) -> pl.DataFrame:
+    ...
+```
+
+## Entity Relationships
+
+1. **Strategy** owns **Custom Indicators**.
+2. **BacktestEngine** extracts **Custom Indicators** from **Strategy**.
+3. **BacktestEngine** passes **Custom Indicators** to **IndicatorDispatcher**.
+4. **IndicatorDispatcher** resolves names: **Custom Indicators** (check first) -> **Global Registry** (check second).
+
+## Validation
+
+- Custom indicator names MUST follow standard regex `^[a-z_]+(\(.*\))?$`.
+- Collisions with global registry are ALLOWED (strategy overrides global).

--- a/specs/026-decouple-indicators/plan.md
+++ b/specs/026-decouple-indicators/plan.md
@@ -1,0 +1,68 @@
+# Implementation Plan: Decouple Indicator Registration
+
+**Branch**: `026-decouple-indicators` | **Date**: 2026-01-14 | **Spec**: [spec.md](../spec.md)
+**Input**: Feature specification from `/specs/026-decouple-indicators/spec.md`
+
+**Note**: This template is filled in by the `/speckit.plan` command. See `.specify/templates/commands/plan.md` for the execution workflow.
+
+## Summary
+
+Enable strategies to define custom indicators via `get_custom_indicators(self)` returning `dict[str, Callable]`. The core backtest engine will resolve these strategy-specific indicators before checking the global registry, allowing for portable strategies and safe overrides without modifying the core codebase.
+
+## Technical Context
+
+**Language/Version**: Python 3.11+
+**Primary Dependencies**: Polars (data processing), Strategy Base Class
+**Storage**: N/A (in-memory processing)
+**Testing**: Pytest (unit & integration)
+**Target Platform**: Local Windows/Linux Environment
+**Project Type**: Single Python Project
+**Performance Goals**: Negligible overhead for indicator resolution; vectorized calculation speed maintained
+**Constraints**: Must maintain backward compatibility for all existing strategies
+**Scale/Scope**: Supports arbitrary number of custom indicators per strategy
+
+## Constitution Check
+
+_GATE: Must pass before Phase 0 research. Re-check after Phase 1 design._
+
+- [x] **Principle I: Strategy-First Architecture**: Changes enforce clearer separation of strategy logic from core engine.
+- [x] **Principle X: Code Quality**: New code will adhere to lint/format standards.
+- [x] **Principle XII: Task Tracking**: Tasks will be generated and tracked in `tasks.md`.
+- [x] **Risk Management**: No changes to risk modules; existing controls apply to strategies using custom indicators.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/026-decouple-indicators/
+├── plan.md              # This file (/speckit.plan command output)
+├── research.md          # Phase 0 output (/speckit.plan command)
+├── data-model.md        # Phase 1 output (/speckit.plan command)
+├── quickstart.md        # Phase 1 output (/speckit.plan command)
+├── contracts/           # Phase 1 output (/speckit.plan command)
+└── tasks.md             # Phase 2 output (/speckit.tasks command - NOT created by /speckit.plan)
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── indicators/       # dispatcher.py logic updates
+├── strategy/         # base.py interface updates
+└── ...
+
+tests/
+├── integration/      # Verify custom indicator resolution
+└── unit/             # Test strategy method & dispatcher logic
+```
+
+**Structure Decision**: Standard "Single project" structure for this Python backend repository. Changes are focused on `src/indicators/dispatcher.py` and `src/strategy/base.py`.
+
+## Complexity Tracking
+
+> **Fill ONLY if Constitution Check has violations that must be justified**
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+| --------- | ---------- | ------------------------------------ |
+| None      | N/A        | N/A                                  |

--- a/specs/026-decouple-indicators/quickstart.md
+++ b/specs/026-decouple-indicators/quickstart.md
@@ -1,0 +1,63 @@
+# Quickstart: Custom Strategy Indicators
+
+## Defining a Custom Indicator
+
+To use a custom indicator in your strategy, define the calculation function and expose it via `get_custom_indicators`.
+
+### 1. Define the Calculation Function
+
+The function must accept a Polars DataFrame and return it with the new column appended.
+
+```python
+import polars as pl
+
+def my_custom_momentum(df: pl.DataFrame, period: int = 10, output_col: str = "mom") -> pl.DataFrame:
+    return df.with_columns(
+        (pl.col("close") / pl.col("close").shift(period) - 1).alias(output_col)
+    )
+```
+
+### 2. Register in Strategy
+
+Override `get_custom_indicators` in your strategy class.
+
+```python
+from src.strategy.base import Strategy
+
+class MyStrategy(Strategy):
+    def get_custom_indicators(self):
+        return {
+            "my_momentum": my_custom_momentum
+        }
+
+    def generate_signals(self, df):
+        # Use the custom indicator
+        # Note: 'my_momentum' is available as a column if requested in config
+        pass
+```
+
+### 3. Use in Configuration
+
+Reference the indicator by name (and optional params) in your config/presets.
+
+```yaml
+indicators:
+  - "ema_20"
+  - "my_momentum(period=14)"
+```
+
+## Overriding Global Indicators
+
+You can replace a standard indicator by registering the same name.
+
+```python
+def my_better_rsi(df, **kwargs):
+    # ... custom logic ...
+    return df
+
+class MyStrategy(Strategy):
+    def get_custom_indicators(self):
+        return {
+            "rsi": my_better_rsi
+        }
+```

--- a/specs/026-decouple-indicators/research.md
+++ b/specs/026-decouple-indicators/research.md
@@ -1,0 +1,32 @@
+# Research: Decouple Indicator Registration
+
+## Research Questions
+
+### 1. How to inject strategy-specific indicators into the calculation pipeline?
+
+**Context**: The `calculate_indicators` function in `src/indicators/dispatcher.py` currently relies on a static `REGISTRY`. We need to pass strategy-specific definitions to it.
+
+**Decision**: Update `calculate_indicators` to accept an optional `overrides` dictionary (already present) OR a `custom_registry` dictionary that is checked before the global registry.
+_Refinement_: The existing `overrides` parameter in `calculate_indicators` serves a different purpose (parameter overrides, not function overrides). We should add a new parameter `custom_registry` or `strategy_indicators`.
+
+**Rationale**: Explicit is better than implicit. overloading `overrides` might be confusing.
+**Selected Approach**: Add `custom_registry: dict[str, Callable] | None = None` to `calculate_indicators` signature.
+
+### 2. How to expose indicators from Strategy?
+
+**Context**: Confirmed in Clarification Phase.
+**Decision**: `get_custom_indicators(self)` instance method.
+**Rationale**: Allows dynamic creation and inheritance.
+
+## Architecture Decisions
+
+1. **Protocol**: Strategies implement `get_custom_indicators` returning `dict[str, Callable]`.
+2. **Dispatch**: `dispatcher.calculate_indicators` updated to accept `custom_registry`.
+3. **Orchestrator**: `run_backtest` (or `BatchSimulation`) retrieves indicators from strategy instance and passes them into the ingestion/enrichment pipeline.
+
+## Alternatives Considered
+
+- **Global Registry Modification**: Strategies implicitly registering themselves on import.
+  - _Rejected_: Violates side-effect free imports and isolation.
+- **Decorator-based Registration**: `@register_indicator` on strategy methods.
+  - _Rejected_: Harder to introspect than a simple dictionary return, less flexible for dynamic indicators.

--- a/specs/026-decouple-indicators/spec.md
+++ b/specs/026-decouple-indicators/spec.md
@@ -1,0 +1,88 @@
+# Feature Specification: Decouple Indicator Registration
+
+**Feature Branch**: `026-decouple-indicators`
+**Created**: 2026-01-14
+**Status**: Draft
+**Input**: User description: "Decouple indicator registration to enable strategy-specific indicators without modifying core registry."
+
+## User Scenarios & Testing
+
+### User Story 1 - Strategy-Specific Indicator Definition (Priority: P1)
+
+A strategy developer wants to define and use custom technical indicators (e.g., "ema_55_close", "custom_volatility_band") directly within their strategy class or module, without modifying the global indicator registry or core engine code.
+
+**Why this priority**: This is the core value proposition. It enables creating portable, self-contained strategies and rapid prototyping without "polluting" the global codebase or requiring core PRs for strategy-specific logic.
+
+**Independent Test**: Create a new strategy file (e.g., `TestCustomIndicatorStrategy`), define a simple custom indicator function within it (e.g., returns `close * 1.01`), and run a backtest using this strategy. The backtest should succeed, and the indicator data should be present in the simulation.
+
+**Acceptance Scenarios**:
+
+1. **Given** a strategy that defines a mapping for a custom indicator string (e.g., "my_custom_indicator"), **When** the backtest engine initializes and parses indicators, **Then** it uses the strategy-provided logic to calculate "my_custom_indicator".
+2. **Given** a strategy that uses a custom indicator, **When** the backtest runs, **Then** the indicator values are correctly calculated and available to the strategy logic (signals/rules).
+3. **Given** a strategy file containing a custom indicator, **When** valid parameters are passed, **Then** the backtest completes without "Indicator not found" errors.
+
+---
+
+### User Story 2 - Backward Compatibility (Priority: P1)
+
+Existing strategies that rely on the global indicator registry MUST continue to function exactly as before.
+
+**Why this priority**: Ensuring no regressions for the existing strategy library is critical.
+
+**Independent Test**: Run the full suite of existing integration tests and sample strategy backtests.
+
+**Acceptance Scenarios**:
+
+1. **Given** a standard strategy using global indicators (e.g., "rsi_14", "sma_200"), **When** a backtest is run, **Then** the system resolves these indicators using the global registry.
+2. **Given** a strategy uses _both_ global and custom indicators, **When** a backtest is run, **Then** both are resolved correctly.
+
+### Edge Cases
+
+- **Naming Conflict**: What happens if a strategy defines an indicator with the same name as a global one?
+
+  - _Expected Behavior_: The backtest engine prioritizes the strategy's definition, allowing strategies to override default behavior if desired.
+
+- **Invalid Custom Implementation**: What happens if the strategy's custom indicator function raises an exception during execution?
+
+  - _Expected Behavior_: The system catches the error, logs it with context (Strategy Name, Indicator Name, Error Message), and halts the backtest with a clear failure message.
+
+- **Missing Indicator**: What happens if a strategy requests an indicator that is neither in the global registry nor defined by the strategy?
+
+  - _Expected Behavior_: The system fails fast with a "Indicator not found: [Name]" error, listing available strategy-specific indicators in the error message if possible.
+
+- **Missing Dependency**: What happens if a custom indicator requires data columns that are not present?
+  - _Expected Behavior_: Standard pandas/numpy errors usually occur. The system should ideally catch `KeyError` during enrichment and provide a helpful message suggesting the data might be missing.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: The `Strategy` class MUST provide a `get_custom_indicators(self)` method returning a `dict[str, Callable]` of indicator definitions.
+- **FR-002**: The backtest orchestration/data ingestion pipeline MUST query the Strategy for indicator definitions when (or before/after) looking up the global registry.
+- **FR-003**: Strategy-defined indicators MUST take precedence over or fallback to the global registry (Need to define precedence: typically local > global allows overriding).
+  - _Assumption_: Strategy-specific definitions take precedence to allow overriding global behavior if desired.
+- **FR-004**: Custom indicators MUST support the same interface as global indicators (accepting `ohlcv` data, returning enriched DataFrame/Series).
+- **FR-005**: The solution MUST allow defining indicators that require parameters (parsed from the string, e.g., "my_indicator_10_2.5").
+
+### Assumptions
+
+- **Standard Parsing**: Custom indicators MUST follow the standard naming conventions (e.g., `name(args)` or `name123`) to be correctly parsed by the core engine's `parse_indicator_string` utility. Custom filtering/parsing logic is out of scope.
+
+### Key Entities
+
+- **Strategy**: The base class or interface will be extended to support indicator lookup/registration.,
+- **IndicatorRegistry**: The existing component that currently holds all mappings.
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001**: A new strategy with a unique, non-global indicator can be implemented and backtested adding files ONLY in the `src/strategy/` directory (and its subdirectories).
+- **SC-002**: 100% of existing strategies and integration tests pass without modification.
+- **SC-003**: Verify that a strategy can define at least 1 custom indicator and use it in a signal generation rule.
+
+## Clarifications
+
+### Session 2026-01-14
+
+- Q: How should strategies define custom indicators? -> A: Use an instance method `get_custom_indicators(self)` returning `dict[str, Callable]`.

--- a/specs/026-decouple-indicators/tasks.md
+++ b/specs/026-decouple-indicators/tasks.md
@@ -1,0 +1,37 @@
+# Tasks: Decouple Indicator Registration
+
+**Feature**: Decouple Indicator Registration (026-decouple-indicators)
+**Status**: In Progress
+
+## Dependencies
+
+- **US1** (Strategy Indicators) must be completed before **US2** (Backward Compatibility/Verification).
+
+## Phase 1: Foundational
+
+- [ ] T001 [US1] Add `get_custom_indicators` method to `Strategy` base class in `src/strategy/base.py`
+
+## Phase 2: User Story 1 - Strategy-Specific Indicators
+
+**Goal**: Enable strategies to define and use custom indicators.
+
+- [ ] T002 [US1] Update `calculate_indicators` in `src/indicators/dispatcher.py` to accept `custom_registry`
+- [ ] T003 [US1] Implement lookup precedence logic (custom > global) in `src/indicators/dispatcher.py`
+- [ ] T004 [US1] Update call site in `src/backtest/engine.py` (`run_portfolio_backtest`) to pass strategy indicators
+- [ ] T005 [US1] Update call site in `src/backtest/engine.py` (`run_multi_symbol_backtest`) to pass strategy indicators
+- [ ] T006 [US1] Update call site in `src/backtest/portfolio/independent_runner.py` (`_run_symbol_backtest`) to pass strategy indicators
+
+## Phase 3: User Story 2 - Backward Compatibility & Verification
+
+**Goal**: Ensure existing strategies work and new custom indicators function correctly.
+
+- [ ] T007 [US2] Create reproduction test case `tests/integration/test_custom_indicators.py` verifying custom indicator logic
+- [ ] T008 [US2] Run full integration suite `tests/integration/` to ensure no regressions
+- [ ] T009 [US2] Verify `run_backtest` CLI still works with `trend_pullback` (standard indicators)
+
+## Implementation Strategy
+
+1. **Foundational**: Update the base class first so all strategies inherit the new method (returning empty dict by default).
+2. **Dispatcher**: Update the core logic to handle the new parameter.
+3. **Integration**: Wire up the orchestrators to pass the data.
+4. **Verification**: Add a test that defines a custom indicator and asserts it runs.


### PR DESCRIPTION
## Summary

Decouples indicator registration logic, enabling strategies to define their own custom indicators via \get_custom_indicators\ and prioritizing them over global defaults.

## Changes

### Strategy
- Added \get_custom_indicators\ method to \Strategy\ Protocol (default empty dict).

### Indicators
- Updated \calculate_indicators\ to accept \custom_registry\.
- Implemented lookup precedence (Custom > Global).

### Backtest Engine
- Wiring: Strategies now pass custom indicators to the dispatcher.
- Fixed CLI \un_backtest.py\ regression with argument packing.

## Testing

- [x] Unit tests pass
- [x] Integration tests pass (\poetry run pytest tests/integration/\)
- [x] Manual testing completed (Verified CLI with \	rend-pullback\)

## Checklist

- [x] Code follows project conventions
- [x] Documentation updated (Walkthrough created)
- [x] No new lint warnings

## Related Issues

Closes #54