### PR TITLE
[FIX] StrategyParameters attribute names in integration tests

### DIFF
--- a/tests/integration/test_strategy_signal_counts.py
+++ b/tests/integration/test_strategy_signal_counts.py
@@ -120,8 +120,8 @@ def run_v2_backtest(
         "atr_multiplier": parameters.atr_stop_mult,
         "risk_reward_ratio": parameters.target_r_mult,
         "trend_cross_count_threshold": 3,
-        "rsi_oversold": parameters.rsi_oversold,
-        "rsi_overbought": parameters.rsi_overbought,
+        "rsi_oversold": parameters.oversold_threshold,
+        "rsi_overbought": parameters.overbought_threshold,
         "stoch_rsi_low": 0.2,
         "stoch_rsi_high": 0.8,
         "prioritize_recent": True,
@@ -301,7 +301,7 @@ class TestSignalCountByDirection:
         params_conservative = StrategyParameters(
             risk_per_trade_pct=0.25,
             account_balance=10000.0,
-            rsi_oversold=20.0,
+            oversold_threshold=20.0,
         )
 
         result_conservative = run_v2_backtest(

--- a/tests/integration/test_us1_long_signal.py
+++ b/tests/integration/test_us1_long_signal.py
@@ -127,8 +127,8 @@ class TestUS1LongSignalIntegration:
             "risk_reward_ratio": parameters.target_r_mult,
             # Test defaults
             "trend_cross_count_threshold": 3,
-            "rsi_oversold": 30.0,
-            "rsi_overbought": 70.0,
+            "rsi_oversold": parameters.oversold_threshold,
+            "rsi_overbought": parameters.overbought_threshold,
             "stoch_rsi_low": 0.2,
             "stoch_rsi_high": 0.8,
             "prioritize_recent": True,


### PR DESCRIPTION
This PR fixes the `AttributeError: 'StrategyParameters' object has no attribute 'rsi_oversold'` failures in integration tests by mapping to the correct Pydantic field names:

- `rsi_oversold` -> `oversold_threshold`
- `rsi_overbought` -> `overbought_threshold`