### PR TITLE
[FIX] Ensure signal generation in integration tests

### DIFF
--- a/tests/integration/test_us1_long_signal.py
+++ b/tests/integration/test_us1_long_signal.py
@@ -123,8 +123,10 @@ class TestUS1LongSignalIntegration:
             "ema_fast": parameters.ema_fast,
             "ema_slow": parameters.ema_slow,
             "rsi_period": parameters.rsi_length,
-            "atr_multiplier": parameters.atr_stop_mult,
+            "stop_loss_atr_multiplier": parameters.atr_stop_mult,
             "risk_reward_ratio": parameters.target_r_mult,
+            "risk_per_trade_pct": parameters.risk_per_trade_pct,
+            "account_balance": parameters.account_balance,
             # Test defaults
             "trend_cross_count_threshold": 3,
             "rsi_oversold": parameters.oversold_threshold,


### PR DESCRIPTION
This PR addresses the remaining integration test failures (`assert 0 > 0`) following the merge of #66. 

Key changes:
1. **Synthetic Data**: Refactored `eurusd_price_data` fixture to generate a deterministic trend-pullback-reversal pattern. The previous data was too simple to trigger the strategy criteria.
2. **Parameter Mapping**: Corrected the parameter dictionary passed to `generate_long_signals` to include missing fields like `stop_loss_atr_multiplier` and `risk_per_trade_pct`.