### PR TITLE
[DOCS] Update CLI commands to use unified quantpipe entry point

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ The project is motivated in part by the requirements of proprietary trading firm
 poetry install
 
 # 2. Run a sample backtest (uses default test dataset)
-poetry run python -m src.cli.run_backtest --pair EURUSD --direction LONG
+poetry run quantpipe backtest --pair EURUSD --direction LONG
 
 # 3. (Optional) JSON output with validate dataset
-poetry run python -m src.cli.run_backtest `
+poetry run quantpipe backtest `
 --pair EURUSD `
 --dataset validate `
 --direction BOTH `
@@ -72,13 +72,13 @@ price_data/
 
 ```powershell
 # Uses: price_data/processed/eurusd/test/eurusd_test.parquet (or .csv if .parquet not found)
-poetry run python -m src.cli.run_backtest --pair EURUSD --direction LONG
+poetry run quantpipe backtest --pair EURUSD --direction LONG
 
 # Uses: price_data/processed/usdjpy/validate/usdjpy_validate.parquet (or .csv if .parquet not found)
-poetry run python -m src.cli.run_backtest --pair USDJPY --dataset validate --direction BOTH
+poetry run quantpipe backtest --pair USDJPY --dataset validate --direction BOTH
 
 # Custom data path (overrides auto-construction)
-poetry run python -m src.cli.run_backtest --data custom/path/data.csv --direction LONG
+poetry run quantpipe backtest --data custom/path/data.csv --direction LONG
 ```
 
 **File Format Support**: Both Parquet (.parquet) and CSV (.csv) formats are supported. Parquet files are loaded directly for optimal performance, while CSV files are automatically preprocessed (MetaTrader format conversion) and cached as Parquet for future runs.
@@ -104,13 +104,13 @@ Run strategies on higher timeframes by resampling from 1-minute data:
 
 ```powershell
 # 15-minute bars
-poetry run python -m src.cli.run_backtest --pair EURUSD --direction BOTH --timeframe 15m
+poetry run quantpipe backtest --pair EURUSD --direction BOTH --timeframe 15m
 
 # 1-hour bars
-poetry run python -m src.cli.run_backtest --pair EURUSD --direction LONG --timeframe 1h
+poetry run quantpipe backtest --pair EURUSD --direction LONG --timeframe 1h
 
 # Arbitrary timeframes (7m, 90m, etc.)
-poetry run python -m src.cli.run_backtest --pair EURUSD --timeframe 7m --direction BOTH
+poetry run quantpipe backtest --pair EURUSD --timeframe 7m --direction BOTH
 ```
 
 Supported formats: `Xm` (minutes), `Xh` (hours), `Xd` (days). Any positive integer works.
@@ -123,17 +123,17 @@ Run multiple strategies simultaneously with weighted portfolio aggregation:
 
 ```powershell
 # Register and list strategies
-poetry run python -m src.cli.run_backtest --register-strategy alpha --strategy-module my_strategies.alpha
-poetry run python -m src.cli.run_backtest --list-strategies
+poetry run quantpipe backtest --register-strategy alpha --strategy-module my_strategies.alpha
+poetry run quantpipe backtest --list-strategies
 
 # Execute specific strategies with custom weights
-poetry run python -m src.cli.run_backtest `
+poetry run quantpipe backtest `
 --pair EURUSD `
 --strategies alpha beta `
 --weights 0.6 0.4
 
 # Equal-weight fallback (no weights specified)
-poetry run python -m src.cli.run_backtest `
+poetry run quantpipe backtest `
 --pair EURUSD `
 --strategies alpha beta gamma
 ```
@@ -143,7 +143,7 @@ See `specs/006-multi-strategy/spec.md` for details on strategy registration, fil
 Example (signals only):
 
 ```powershell
-poetry run python -m src.cli.run_backtest --pair EURUSD --dry-run
+poetry run quantpipe backtest --pair EURUSD --dry-run
 ```
 
 ## Multi-Symbol Portfolio Backtesting
@@ -156,7 +156,7 @@ Each symbol runs in isolation with separate capital and risk limits:
 
 ```powershell
 # Run 3 symbols independently
-poetry run python -m src.cli.run_backtest `
+poetry run quantpipe backtest `
 --direction BOTH `
 --pair EURUSD GBPUSD USDJPY `
 --portfolio-mode independent
@@ -175,7 +175,7 @@ Shared capital pool with correlation tracking and dynamic allocation:
 
 ```powershell
 # Run portfolio mode with custom correlation threshold
-poetry run python -m src.cli.run_backtest `
+poetry run quantpipe backtest `
 --direction BOTH `
 --pair EURUSD GBPUSD USDJPY `
 --portfolio-mode portfolio `
@@ -197,7 +197,7 @@ Exclude specific symbols at runtime:
 
 ```powershell
 # Run all pairs except GBPUSD
-poetry run python -m src.cli.run_backtest `
+poetry run quantpipe backtest `
 --direction LONG `
 --pair EURUSD GBPUSD USDJPY NZDUSD `
 --disable-symbol GBPUSD
@@ -247,12 +247,12 @@ The backtesting engine achieves production-grade performance through columnar op
 
 ```powershell
 # Standard optimized backtest (Polars automatic)
-poetry run python -m src.cli.run_backtest `
+poetry run quantpipe backtest `
 --pair EURUSD `
 --direction BOTH
 
 # Profile with first 25% of data
-poetry run python -m src.cli.run_backtest `
+poetry run quantpipe backtest `
 --pair EURUSD `
 --direction BOTH `
 --data-frac 0.25 `
@@ -278,7 +278,7 @@ See `docs/performance.md` for complete optimization guide, architecture details,
 Add `--visualize` to any backtest command for interactive charting:
 
 ```powershell
-poetry run python -m src.cli.run_backtest --pair EURUSD --direction BOTH --visualize
+poetry run quantpipe backtest --pair EURUSD --direction BOTH --visualize
 ```
 
 **Features:**

--- a/docs/backtesting.md
+++ b/docs/backtesting.md
@@ -26,10 +26,10 @@ This document explains how datasets are prepared and how the backtesting framewo
 
    ```powershell
    # If you converted MT format files:
-   poetry run python -m src.cli.build_dataset --symbol eurusd --raw-path price_data/raw_converted
+   poetry run quantpipe ingest --symbol eurusd --raw-path price_data/raw_converted
 
    # If you already have standard format files (with timestamp,open,high,low,close,volume header):
-   poetry run python -m src.cli.build_dataset --symbol eurusd
+   poetry run quantpipe ingest --symbol eurusd
    ```
 
 4. Generated structure:
@@ -60,7 +60,7 @@ This document explains how datasets are prepared and how the backtesting framewo
 
 | Mode       | Command                      | Purpose                                             |
 | ---------- | ---------------------------- | --------------------------------------------------- |
-| Single run | `src.cli.run_backtest`       | Run on any CSV file                                 |
+| Single run | `quantpipe backtest`         | Run on any CSV file                                 |
 | Split-mode | `src.cli.run_split_backtest` | Automatically evaluate test & validation partitions |
 
 ### Single-Symbol Baseline Behavior

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -173,13 +173,13 @@ poetry run pytest tests/performance/benchmark_ingestion.py -v -m performance
 
 ```bash
 # Enable profiling with automatic benchmark output
-poetry run python -m src.cli.run_backtest \
+poetry run quantpipe backtest \
   --data ./price_data/processed/eurusd/test/eurusd_test.csv \
   --direction BOTH \
   --profile
 
 # Specify custom benchmark output path
-poetry run python -m src.cli.run_backtest \
+poetry run quantpipe backtest \
   --data ./price_data/processed/eurusd/test/eurusd_test.csv \
   --direction BOTH \
   --profile \
@@ -219,25 +219,25 @@ poetry run python -m src.cli.run_backtest \
 
 ```bash
 # Interactive prompt for fraction (press Enter for default=1.0)
-poetry run python -m src.cli.run_backtest \
+poetry run quantpipe backtest \
   --data ./price_data/processed/eurusd/test/eurusd_test.csv \
   --direction BOTH
 
 # Quick validation: Process first 25% of dataset
-poetry run python -m src.cli.run_backtest \
+poetry run quantpipe backtest \
   --data ./price_data/processed/eurusd/test/eurusd_test.csv \
   --direction BOTH \
   --data-frac 0.25
 
 # Test second quartile specifically
-poetry run python -m src.cli.run_backtest \
+poetry run quantpipe backtest \
   --data ./price_data/processed/eurusd/test/eurusd_test.csv \
   --direction BOTH \
   --data-frac 0.25 \
   --portion 2
 
 # Half dataset (first half)
-poetry run python -m src.cli.run_backtest \
+poetry run quantpipe backtest \
   --data ./price_data/processed/eurusd/test/eurusd_test.csv \
   --direction BOTH \
   --data-frac 0.5 \
@@ -333,19 +333,19 @@ TOTAL          1,200      100%      4.4×
 
 ```bash
 # Standard optimized run
-poetry run python -m src.cli.run_backtest \
+poetry run quantpipe backtest \
   --data ./price_data/processed/eurusd/test/eurusd_test.csv \
   --direction BOTH
 
 # With profiling enabled (Phase 4)
-poetry run python -m src.cli.run_backtest \
+poetry run quantpipe backtest \
   --data ./price_data/processed/eurusd/test/eurusd_test.csv \
   --direction BOTH \
   --profile \
   --benchmark-out ./results/benchmarks/run_001.json
 
 # Deterministic mode for reproducibility
-poetry run python -m src.cli.run_backtest \
+poetry run quantpipe backtest \
   --data ./price_data/processed/eurusd/test/eurusd_test.csv \
   --direction BOTH \
   --deterministic
@@ -419,7 +419,7 @@ Example:
 
 ```bash
 # Run profiling
-poetry run python -m src.cli.run_backtest --data <path> --direction BOTH --profile
+poetry run quantpipe backtest --data <path> --direction BOTH --profile
 
 # Check hotspots in benchmark file
 cat results/benchmarks/benchmark_*.json | jq '.hotspots[] | {function, cumtime}'
@@ -818,7 +818,7 @@ def test_eurusd_equivalence():
 **Basic Backtest** (Polars ingestion automatic):
 
 ```bash
-poetry run python -m src.cli.run_backtest \
+poetry run quantpipe backtest \
   --data price_data/processed/eurusd/eurusd_2020.csv \
   --direction BOTH
 ```

--- a/docs/strategy_authoring.md
+++ b/docs/strategy_authoring.md
@@ -9,7 +9,7 @@ with indicators and risk management.
 Generate a new strategy scaffold:
 
 ```bash
-poetry run python -m src.cli.scaffold_strategy my_strategy
+poetry run quantpipe new_strategy --name my_strategy
 ```
 
 This creates `src/strategy/my_strategy/` with template files ready to customize.
@@ -288,7 +288,7 @@ See these strategies for reference:
 Run a backtest:
 
 ```bash
-poetry run python -m src.cli.run_backtest \
+poetry run quantpipe backtest \
     --strategy simple_momentum \
     --data price_data/EURUSD_15m.csv \
     --manifest price_data/manifest.yaml

--- a/docs/timeframes.md
+++ b/docs/timeframes.md
@@ -6,13 +6,13 @@ This document describes how to use the multi-timeframe backtesting feature to ru
 
 ```bash
 # Run backtest with 15-minute timeframe
-poetry run python -m src.cli.run_backtest \
+poetry run quantpipe backtest \
     --pair EURUSD \
     --direction LONG \
     --timeframe 15m
 
 # Run with 1-hour timeframe
-poetry run python -m src.cli.run_backtest \
+poetry run quantpipe backtest \
     --pair EURUSD \
     --direction BOTH \
     --timeframe 1h
@@ -116,28 +116,28 @@ Higher timeframes process significantly faster due to fewer bars.
 
 ```bash
 # 5-minute backtest
-poetry run python -m src.cli.run_backtest --pair EURUSD --direction LONG --timeframe 5m
+poetry run quantpipe backtest --pair EURUSD --direction LONG --timeframe 5m
 
 # 4-hour backtest
-poetry run python -m src.cli.run_backtest --pair GBPUSD --direction SHORT --timeframe 4h
+poetry run quantpipe backtest --pair GBPUSD --direction SHORT --timeframe 4h
 ```
 
 ### Custom Timeframes
 
 ```bash
 # 7-minute bars (custom)
-poetry run python -m src.cli.run_backtest --pair USDJPY --timeframe 7m --direction BOTH
+poetry run quantpipe backtest --pair USDJPY --timeframe 7m --direction BOTH
 
 # 90-minute bars (1.5 hours)
-poetry run python -m src.cli.run_backtest --pair EURUSD --timeframe 90m --direction LONG
+poetry run quantpipe backtest --pair EURUSD --timeframe 90m --direction LONG
 ```
 
 ### With Config File
 
 ```bash
 # Use config file defaults
-poetry run python -m src.cli.run_backtest --config backtest_config.yaml
+poetry run quantpipe backtest --config backtest_config.yaml
 
 # Override config timeframe with CLI
-poetry run python -m src.cli.run_backtest --config backtest_config.yaml --timeframe 1h
+poetry run quantpipe backtest --config backtest_config.yaml --timeframe 1h
 ```

--- a/docs/visualization.md
+++ b/docs/visualization.md
@@ -9,7 +9,7 @@ This document describes the interactive visualization system for backtest result
 Add `--visualize` to any backtest command to open an interactive chart:
 
 ```powershell
-poetry run python -m src.cli.run_backtest --pair EURUSD --direction BOTH --visualize
+poetry run quantpipe backtest --pair EURUSD --direction BOTH --visualize
 ```
 
 ## Features
@@ -117,11 +117,11 @@ All timestamps are normalized to `datetime64[ns]` timezone-naive format using th
 
 ```powershell
 # Basic visualization
-poetry run python -m src.cli.run_backtest --pair EURUSD --visualize --direction BOTH
+poetry run quantpipe backtest --pair EURUSD --visualize --direction BOTH
 
 # With date range
-poetry run python -m src.cli.run_backtest --pair EURUSD --visualize --direction LONG --start-date 2021-01-01 --end-date 2021-01-31
+poetry run quantpipe backtest --pair EURUSD --visualize --direction LONG --start-date 2021-01-01 --end-date 2021-01-31
 
 # Save to file (HTML)
-poetry run python -m src.cli.run_backtest --pair EURUSD --visualize --output-file results.html
+poetry run quantpipe backtest --pair EURUSD --visualize --output-file results.html
 ```


### PR DESCRIPTION
This PR updates the core documentation to reflect the recent packaging changes. All examples have been updated to use the `poetry run quantpipe` entry point instead of the long `python -m src.cli...` commands.

Updated files:
- `README.md`
- `docs/backtesting.md`
- `docs/performance.md`
- `docs/strategy_authoring.md`
- `docs/timeframes.md`
- `docs/visualization.md`