### PR TITLE
security: fix CVE-2026-25990 by updating Pillow to 12.1.1

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3349,4 +3349,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "fad163e891a25449c7c1a53c88ffb4c1850b352b2ca71cc51380c76e9ffd31f6"
+content-hash = "551c819d95ef00b393d6a57b8e0cfde1e6313cab22121c477ad416a01476bced"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ panel = "^1.4.0"
 bokeh = "^3.8.2"
 dask = "^2024.1.0"  # Pin to 2024.x for Datashader compatibility (2025.x has breaking changes)
 questionary = "^2.1.1"
-pillow = ">=12.1.1"
+pillow = "^12.1.1"
 tornado = ">=6.5.5"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
This updates Pillow to 12.1.1 to address the out-of-bounds write vulnerability when loading PSD images (CVE-2026-25990). The lock file is updated accordingly and the constraint is pinned to ^12.1.1 for safety.