### PR TITLE
security: bump pytest 8.3.4 → 9.0.3 (CVE-2025-71176)

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2518,20 +2518,20 @@ testutils = ["gitpython (>3)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["dev"]
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 
@@ -3416,4 +3416,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "69cb273a50387ceb8a40b298c3e75b00480b219d3084b9a6661dc46bbed29db5"
+content-hash = "3bad7f55a553369d1092262f7771f3df2b4ed46a55708a4579037f7c6198e477"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ pillow = "^12.2.0"
 tornado = ">=6.5.5"
 
 [tool.poetry.group.dev.dependencies]
-pytest = "^8.3.4"
+pytest = "^9.0.3"
 pytest-benchmark = "^4.0.0"
 hypothesis = "^6.88.0"
 ruff = "^0.1.0"


### PR DESCRIPTION
Fixes CVE-2025-71176 / GHSA-6w46-j5rx-g56g

- Bumps `pytest` from ^8.3.4 to ^9.0.3
- Fixes insecure temporary directory handling (tmpdir symlink attacks / TOCTOU races)
- https://github.com/pytest-dev/pytest/issues/14343

No code changes required — pytest 9.x is backward-compatible with the existing test suite.