### PR TITLE
security: bump idna 3.11 → 3.15 (CVE-2026-45409)

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -845,18 +845,18 @@ zoneinfo = ["tzdata (>=2025.3) ; sys_platform == \"win32\" or sys_platform == \"
 
 [[package]]
 name = "idna"
-version = "3.11"
+version = "3.15"
 description = "Internationalized Domain Names in Applications (IDNA)"
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
 files = [
-    {file = "idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea"},
-    {file = "idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902"},
+    {file = "idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8"},
+    {file = "idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc"},
 ]
 
 [package.extras]
-all = ["flake8 (>=7.1.1)", "mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2)"]
+all = ["mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2)"]
 
 [[package]]
 name = "iniconfig"


### PR DESCRIPTION
**Security fix for CVE-2026-45409**

Bumps `idna` from 3.11 to 3.15 to address a medium-severity Dependabot alert.

- **CVE:** CVE-2026-45409
- **Severity:** Medium
- **Description:** Specially crafted inputs to `idna.encode()` can bypass CVE-2024-3651 fix
- **Package:** `idna` (pip)
- **Manifest:** `poetry.lock`

Generated via `poetry update idna`.